### PR TITLE
workaround for file not found Errno::ENOENT

### DIFF
--- a/stackskills_dl.rb
+++ b/stackskills_dl.rb
@@ -8,7 +8,7 @@ def escape_chars(str)
 end
 
 def mkchdir(dir)
-  Dir.mkdir(dir) unless Dir.exist?(dir)
+  system 'mkdir', '-p', dir
   Dir.chdir(dir) do
     yield
   end


### PR DESCRIPTION
The script wasn't able to create a nested folder structure like `test/abc` without throwing a error message "workaround for file not found Errno::ENOENT".

There's probably a better way to fix.