### PR TITLE
Updated video download scraping

### DIFF
--- a/stackskills_dl.rb
+++ b/stackskills_dl.rb
@@ -15,7 +15,7 @@ def mkchdir(dir)
 end
 
 def download_video(page, lecture_name)
-  video = page.link_with(href: /.mp4/)
+  video = page.link_with(href: /filepicker.io/)
   if video
     `wget #{video.href} -c -O #{lecture_name}.mp4`
   else


### PR DESCRIPTION
Looks like StackSkills changed their URL in the download links, it's now from filepicker.io, so I've updated that

Resolves the issue I identified yesterday.